### PR TITLE
🧩 Add Agent Feedback Webhook + GitHub Logger

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## [Agent Feedback System] - 2025-06-11
+
+### Added
+- New webhook workflow for capturing agent feedback and errors
+- GitHub feedback logger script to store errors in repository
+- Test payload for webhook validation
+- Integration with GitHub API for error logging
+
+### Technical Details
+- Webhook accepts POST requests with agent_id, error_type, and message
+- Python script interfaces with GitHub API to update error logs
+- Error data stored in .github/feedback/agent_errors.json
+- Includes error context and timestamps for debugging

--- a/scripts/github_feedback_logger.py
+++ b/scripts/github_feedback_logger.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+import json
+import os
+import sys
+from datetime import datetime
+from github import Github
+from pathlib import Path
+
+def load_existing_errors(repo, file_path):
+    """Load existing errors from GitHub."""
+    try:
+        content = repo.get_contents(file_path)
+        return json.loads(content.decoded_content)
+    except:
+        return []
+
+def update_error_log(token, repo_name, file_path, new_error):
+    """Update error log in GitHub repository."""
+    g = Github(token)
+    repo = g.get_repo(repo_name)
+    
+    # Load existing errors
+    errors = load_existing_errors(repo, file_path)
+    
+    # Add new error
+    errors.append(new_error)
+    
+    # Update file in GitHub
+    content = json.dumps(errors, indent=2)
+    try:
+        contents = repo.get_contents(file_path)
+        repo.update_file(
+            file_path,
+            f"📝 Log agent error: {new_error['error_type']} for {new_error['agent_id']}",
+            content,
+            contents.sha
+        )
+    except:
+        repo.create_file(
+            file_path,
+            f"📝 Create agent error log",
+            content
+        )
+
+def main():
+    # Get error data from n8n workflow
+    if len(sys.argv) < 2:
+        print("Error: No data provided")
+        sys.exit(1)
+        
+    try:
+        error_data = json.loads(sys.argv[1])
+    except json.JSONDecodeError:
+        print("Error: Invalid JSON data")
+        sys.exit(1)
+    
+    # Get GitHub token from environment
+    token = os.getenv('GITHUB_TOKEN')
+    if not token:
+        print("Error: GITHUB_TOKEN environment variable not set")
+        sys.exit(1)
+    
+    # Configuration
+    repo_name = "Peav-Accounting/n8n"
+    file_path = ".github/feedback/agent_errors.json"
+    
+    # Update error log
+    update_error_log(token, repo_name, file_path, error_data)
+    print("Successfully logged error to GitHub")
+
+if __name__ == "__main__":
+    main()

--- a/test/webhook-payload.json
+++ b/test/webhook-payload.json
@@ -1,0 +1,14 @@
+{
+  "agent_id": "B5",
+  "error_type": "validation_error",
+  "message": "Missing required field: vendor_id",
+  "context": {
+    "workflow_id": "bookkeeping_entry_B5",
+    "input_data": {
+      "date": "2025-06-11",
+      "amount": "2500.00",
+      "description": "Office supplies purchase"
+    },
+    "error_location": "vendor_validation_step"
+  }
+}

--- a/workflows/webhook-agent-feedback.json
+++ b/workflows/webhook-agent-feedback.json
@@ -1,0 +1,88 @@
+{
+  "name": "Agent Feedback Webhook",
+  "nodes": [
+    {
+      "id": "webhook",
+      "type": "n8n-nodes-base.webhook",
+      "position": [100, 100],
+      "parameters": {
+        "path": "agent-feedback",
+        "options": {
+          "responseData": "responseNode"
+        },
+        "authentication": "basicAuth",
+        "httpMethod": "POST"
+      }
+    },
+    {
+      "id": "validate_payload",
+      "type": "n8n-nodes-base.function",
+      "position": [300, 100],
+      "parameters": {
+        "functionCode": "// Validate required fields\nconst payload = items[0].json.body;\nif (!payload.agent_id || !payload.error_type || !payload.message) {\n  throw new Error('Missing required fields');\n}\n\n// Add timestamp\nconst error = {\n  timestamp: new Date().toISOString(),\n  agent_id: payload.agent_id,\n  error_type: payload.error_type,\n  message: payload.message,\n  context: payload.context || {}\n};\n\nreturn {json: error};"
+      }
+    },
+    {
+      "id": "execute_python",
+      "type": "n8n-nodes-base.executeCommand",
+      "position": [500, 100],
+      "parameters": {
+        "command": "python3 scripts/github_feedback_logger.py",
+        "arguments": "='{{$json}}'",
+        "executeTimeout": 20
+      }
+    },
+    {
+      "id": "response",
+      "type": "n8n-nodes-base.respond",
+      "position": [700, 100],
+      "parameters": {
+        "options": {
+          "responseBody": "={\"status\": \"success\", \"message\": \"Error logged successfully\"}"
+        }
+      }
+    }
+  ],
+  "connections": {
+    "webhook": {
+      "main": [
+        [
+          {
+            "node": "validate_payload",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "validate_payload": {
+      "main": [
+        [
+          {
+            "node": "execute_python",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "execute_python": {
+      "main": [
+        [
+          {
+            "node": "response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": true,
+  "settings": {
+    "errorWorkflow": "none",
+    "saveManualExecutions": true,
+    "callerPolicy": "workflowsFromSameOwner"
+  },
+  "version": 1
+}


### PR DESCRIPTION
This PR adds a webhook and GitHub-based logging system for capturing and storing agent errors.

## Changes
- Add webhook workflow that accepts POST requests with error data
- Create GitHub feedback logger script to store errors in repository
- Add test payload for webhook validation
- Update changelog with new features

## Implementation Details
- Webhook validates incoming requests for required fields
- Python script interfaces with GitHub API to update error logs
- Errors stored in .github/feedback/agent_errors.json with context
- Includes timestamps and error context for debugging

## Testing
Test the webhook using:
```bash
curl -X POST http://your-n8n-instance/webhook/agent-feedback \
  -H 'Content-Type: application/json' \
  -d @test/webhook-payload.json
```

## Reviewer Notes
This implementation allows live agent errors to be captured and stored in GitHub for review, testing, and improvement suggestions.

/cc @OP://IT/EMPLOYEE_1_EMAIL/email address